### PR TITLE
Fix PrefixLM FA3 zero-causal segment crash

### DIFF
--- a/models/flash_attention_prefixlm_v2.py
+++ b/models/flash_attention_prefixlm_v2.py
@@ -119,13 +119,17 @@ def flash_attn_varlen_prefixlm_compileop(
         seqused_q=prefix_lens, seqused_k=prefix_lens,
         max_seqlen_q=max_seqlen_prefix_int, max_seqlen_k=max_seqlen_prefix_int,
         causal=is_causal)
-    # Fwd pass 2 (causal)
-    _, softmax_lse_causal = _custom_flash_attn_forward(
-        out_=out, q=q, k=k, v=v,
-        cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
-        seqused_q=causal_lens,
-        max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
-        causal=True)
+    # Fwd pass 2 (causal). If every causal segment is empty, this pass is a
+    # no-op; FA3 backward does not reliably handle max_seqlen_q=0.
+    if max_seqlen_causal_int > 0:
+        _, softmax_lse_causal = _custom_flash_attn_forward(
+            out_=out, q=q, k=k, v=v,
+            cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
+            seqused_q=causal_lens,
+            max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
+            causal=True)
+    else:
+        softmax_lse_causal = torch.empty_like(softmax_lse_bidir)
 
     out[total_seqlen_int:] = 0  # Zero padding
     return out, softmax_lse_bidir, softmax_lse_causal
@@ -181,7 +185,7 @@ def flash_attn_varlen_prefixlm_bwd_compileop(
     # Buffers
     dq = torch.empty_like(q)
     dk1, dv1 = torch.zeros_like(k), torch.zeros_like(v)  # Zero-fill in advance
-    dk2, dv2 = torch.empty_like(k), torch.empty_like(v)
+    dk2, dv2 = torch.zeros_like(k), torch.zeros_like(v)
     # Bwd pass 1 (bidirectional)
     _flash_attn_backward(
         dout=dout, q=q, k=k, v=v, out=out,
@@ -194,16 +198,17 @@ def flash_attn_varlen_prefixlm_bwd_compileop(
         dv=dv1,
         is_causal=is_causal)
     # Bwd pass 2 (causal)
-    _flash_attn_backward(
-        dout=dout, q=q, k=k, v=v, out=out,
-        softmax_lse=softmax_lse_causal,
-        cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
-        max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
-        sequed_q=causal_lens,
-        dq=dq,
-        dk=dk2,
-        dv=dv2,
-        is_causal=True)
+    if max_seqlen_causal_int > 0:
+        _flash_attn_backward(
+            dout=dout, q=q, k=k, v=v, out=out,
+            softmax_lse=softmax_lse_causal,
+            cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
+            sequed_q=causal_lens,
+            dq=dq,
+            dk=dk2,
+            dv=dv2,
+            is_causal=True)
 
     # Zero padding grads
     dq[total_seqlen_int:] = 0


### PR DESCRIPTION
## Summary

This fixes a PrefixLM FlashAttention 3 boundary case where a packed batch can have no causal query tokens:

- \`total_seqlen = 4096\`
- \`numseqs = 1\`
- \`max_seqlen_prefix = 4096\`
- \`max_seqlen_causal = 0\`
- \`max_seqlen_all = 4096\`

In this case the causal pass is a no-op. The previous implementation still called the causal FA3 forward/backward pass with \`max_seqlen_q=0\`, which can trigger a Hopper/CUTLASS internal error in \`flash_bwd_launch_template.h\`.

The patch skips the causal FA3 pass when \`max_seqlen_causal == 0\` and keeps the second-pass K/V gradients zero-initialized.

## Validation

- Single H100 zero-causal boundary repro: PASS
- Runtime: PyTorch 2.11.0+cu128, CUDA 12.8, H100 80GB HBM3
- 6 nodes x 8 H100 training validation: reached \`max_steps=2286\`, crossing the previously failing step 2284
- Previous failure: \`CUTLASS error (.../flash_bwd_launch_template.h:75): Error Internal\`

## Notes

This does not change behavior for normal batches where \`max_seqlen_causal > 0\`. It only avoids dispatching an empty causal query pass to FA3.