### PR TITLE
Drop empty-response samples in SFT data prep

### DIFF
--- a/scripts/prepare_sft_data.py
+++ b/scripts/prepare_sft_data.py
@@ -83,6 +83,7 @@ def main():
     inst_len: list[int] = []
     resp_start: list[int] = []
     resp_len: list[int] = []
+    skipped_empty = 0
 
     for r in rows:
         condition = r.get("condition", "direct")
@@ -94,6 +95,12 @@ def main():
 
         inst_ids = tok.encode(r["instruction"], add_special_tokens=False).ids
         resp_ids = tok.encode(r["response"], add_special_tokens=False).ids
+
+        # Empty-response samples produce seqlens_o == 0 at runtime; a packed batch of
+        # only such samples crashes FA3 backward. Drop them at prep time.
+        if not resp_ids:
+            skipped_empty += 1
+            continue
 
         i_start = len(all_tokens)
         all_tokens.append(boq_id)
@@ -108,6 +115,9 @@ def main():
         all_tokens.append(eoa_id)
         resp_start.append(r_start)
         resp_len.append(len(all_tokens) - r_start)
+
+    if skipped_empty:
+        print(f"Skipped {skipped_empty} samples with empty response")
 
     tokens_np = np.array(all_tokens, dtype=np.int32)
     inst_start_np = np.array(inst_start, dtype=np.int64)

--- a/scripts/test_prepare_sft_filter.py
+++ b/scripts/test_prepare_sft_filter.py
@@ -1,0 +1,101 @@
+"""
+Quick functional test for the empty-response filter in prepare_sft_data.py.
+
+Constructs a tiny JSONL with 3 normal samples + 2 empty-response samples,
+runs prepare, and verifies:
+  1. "Skipped 2 samples with empty response" is printed
+  2. Output indices contain only 3 samples (empty ones excluded)
+  3. All resp_len > 1 in the output
+
+CPU-only, takes ~1s. Run from repo root.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Need a tokenizer with the special tokens prepare expects.
+# Reuse whatever the project already ships with, if available.
+TOKENIZER_CANDIDATES = [
+    REPO_ROOT / "assets" / "tokenizer.json",
+    REPO_ROOT / "tokenizer.json",
+]
+
+
+def find_tokenizer() -> Path:
+    for p in TOKENIZER_CANDIDATES:
+        if p.exists():
+            return p
+    print("ERROR: could not find a tokenizer.json. Pass one with TOKENIZER=path env var.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    import os
+    tokenizer = Path(os.environ.get("TOKENIZER", "")) if os.environ.get("TOKENIZER") else find_tokenizer()
+    assert tokenizer.exists(), f"tokenizer not found: {tokenizer}"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        jsonl = tmp / "in.jsonl"
+        out = tmp / "out"
+
+        rows = [
+            {"instruction": "What is 2+2?", "response": "4"},
+            {"instruction": "Capital of France?", "response": "Paris"},
+            {"instruction": "Empty response sample A", "response": ""},   # should be dropped
+            {"instruction": "Hello?", "response": "Hi there"},
+            {"instruction": "Empty response sample B", "response": ""},   # should be dropped
+        ]
+        with open(jsonl, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+        cmd = [
+            sys.executable, str(REPO_ROOT / "scripts" / "prepare_sft_data.py"),
+            "--train", str(jsonl),
+            "--tokenizer", str(tokenizer),
+            "--output", str(out),
+            "--epochs", "1",
+        ]
+        print("Running:", " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        print("--- stdout ---")
+        print(result.stdout)
+        print("--- stderr ---")
+        print(result.stderr)
+
+        if result.returncode != 0:
+            print("FAIL: prepare_sft_data.py exited non-zero")
+            sys.exit(1)
+
+        # Check 1: print message
+        if "Skipped 2 samples with empty response" not in result.stdout:
+            print("FAIL: expected 'Skipped 2 samples with empty response' in stdout")
+            sys.exit(1)
+        print("OK: skipped count printed correctly")
+
+        # Check 2: output has only 3 samples
+        resp_len = np.load(out / "epoch_0" / "resp_len.npy")
+        if len(resp_len) != 3:
+            print(f"FAIL: expected 3 samples in output, got {len(resp_len)}")
+            sys.exit(1)
+        print(f"OK: output has {len(resp_len)} samples (empty ones filtered)")
+
+        # Check 3: all resp_len > 1
+        if not (resp_len > 1).all():
+            print(f"FAIL: some resp_len <= 1 in output: {resp_len.tolist()}")
+            sys.exit(1)
+        print(f"OK: all resp_len > 1, values: {resp_len.tolist()}")
+
+        print("\nAll checks PASSED.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes the loop on the zero-causal FA3 crash (#9, reverted in #10) by addressing it at the data layer.

## Why not the kernel

#9 guarded the FA3 backward with a `max_seqlen_causal == 0` check, but also flipped `dk2/dv2` from `empty_like` to `zeros_like` so the skipped-pass buffers stay safe. That pays a K/V-shaped memset on every backward of every layer — by 99.9% of batches, to defend a boundary that fires once in thousands of steps. Not worth it. Reverted in #10.

## What this does

The trigger is structural: a packed batch where every sample has `causal_len == 0` (empty response). Drop such samples at prep time so the runtime never sees them.

- 9-line change in `scripts/prepare_sft_data.py` + small functional test
- Pretrain path and `dataset_new.py` runtime loader untouched (pretrain shares the loader)
- Tested on devbox with the real tokenizer: 5 samples in (2 empty), 3 out, all `resp_len > 1`

## Migration

Re-run `prepare_sft_data.py` on any existing SFT datasets that may contain empty-response rows. Datasets prepared from valid JSONL are unaffected.

cc @Zane12518 — this is the alternative path we landed on for the crash you caught. Thanks for the clean repro and the careful fix; we just decided the cost/benefit pointed at the data layer instead.