### PR TITLE
Handle zero-causal PrefixLM FA3 pass as no-op

### DIFF
--- a/models/flash_attention_prefixlm_v2.py
+++ b/models/flash_attention_prefixlm_v2.py
@@ -208,14 +208,14 @@ def flash_attn_varlen_prefixlm_bwd_compileop(
             dk=dk2,
             dv=dv2,
             is_causal=True)
-    else:
-        dk2, dv2 = torch.zeros_like(k), torch.zeros_like(v)
+        dk2[total_seqlen_int:] = 0
+        dv2[total_seqlen_int:] = 0
+        dk1.add_(dk2)
+        dv1.add_(dv2)
 
     # Zero padding grads
     dq[total_seqlen_int:] = 0
-    dk2[total_seqlen_int:] = 0
-    dv2[total_seqlen_int:] = 0
-    return dq, dk1.add_(dk2), dv1.add_(dv2)
+    return dq, dk1, dv1
 
 
 @torch.library.register_fake("flash_attn::flash_attn_varlen_prefixlm_bwd_compileop")

--- a/models/flash_attention_prefixlm_v2.py
+++ b/models/flash_attention_prefixlm_v2.py
@@ -120,12 +120,15 @@ def flash_attn_varlen_prefixlm_compileop(
         max_seqlen_q=max_seqlen_prefix_int, max_seqlen_k=max_seqlen_prefix_int,
         causal=is_causal)
     # Fwd pass 2 (causal)
-    _, softmax_lse_causal = _custom_flash_attn_forward(
-        out_=out, q=q, k=k, v=v,
-        cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
-        seqused_q=causal_lens,
-        max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
-        causal=True)
+    if max_seqlen_causal_int > 0:
+        _, softmax_lse_causal = _custom_flash_attn_forward(
+            out_=out, q=q, k=k, v=v,
+            cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
+            seqused_q=causal_lens,
+            max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
+            causal=True)
+    else:
+        softmax_lse_causal = torch.empty_like(softmax_lse_bidir)
 
     out[total_seqlen_int:] = 0  # Zero padding
     return out, softmax_lse_bidir, softmax_lse_causal
@@ -181,7 +184,6 @@ def flash_attn_varlen_prefixlm_bwd_compileop(
     # Buffers
     dq = torch.empty_like(q)
     dk1, dv1 = torch.zeros_like(k), torch.zeros_like(v)  # Zero-fill in advance
-    dk2, dv2 = torch.empty_like(k), torch.empty_like(v)
     # Bwd pass 1 (bidirectional)
     _flash_attn_backward(
         dout=dout, q=q, k=k, v=v, out=out,
@@ -194,16 +196,20 @@ def flash_attn_varlen_prefixlm_bwd_compileop(
         dv=dv1,
         is_causal=is_causal)
     # Bwd pass 2 (causal)
-    _flash_attn_backward(
-        dout=dout, q=q, k=k, v=v, out=out,
-        softmax_lse=softmax_lse_causal,
-        cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
-        max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
-        sequed_q=causal_lens,
-        dq=dq,
-        dk=dk2,
-        dv=dv2,
-        is_causal=True)
+    if max_seqlen_causal_int > 0:
+        dk2, dv2 = torch.empty_like(k), torch.empty_like(v)
+        _flash_attn_backward(
+            dout=dout, q=q, k=k, v=v, out=out,
+            softmax_lse=softmax_lse_causal,
+            cu_seqlens_q=cu_seqlens_shifted, cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen_causal_int, max_seqlen_k=max_seqlen_all_int,
+            sequed_q=causal_lens,
+            dq=dq,
+            dk=dk2,
+            dv=dv2,
+            is_causal=True)
+    else:
+        dk2, dv2 = torch.zeros_like(k), torch.zeros_like(v)
 
     # Zero padding grads
     dq[total_seqlen_int:] = 0


### PR DESCRIPTION
## Summary

This revisits the zero-causal PrefixLM FA3 boundary from #9 while addressing the hot-path cost concern from #10.

The previous runtime guard initialized `dk2/dv2` with `zeros_like` unconditionally, which adds a K/V-shaped memset to every backward. This version keeps the normal path unchanged:

- when `max_seqlen_causal > 0`, allocate `dk2/dv2` with `empty_like` and run the causal FA3 forward/backward as before;
- when `max_seqlen_causal == 0`, skip the causal FA3 forward/backward pass and initialize `dk2/dv2` to zero because the skipped pass is mathematically a no-op.

## Why this may still be useful

The SFT data-layer fix in #11 covers empty-response rows prepared by `scripts/prepare_sft_data.py`. The more general runtime boundary, however, is `final resp_len <= 1` after tokenization/truncation, not only an empty raw response.

For example, a non-empty response can still become zero-causal if the prefix consumes nearly the full context budget:

- `context_size = 4097`
- `inst_len = 4096`
- `allowed_resp = 1`
- `final_resp_len = 1`
- `causal_len = final_resp_len - 1 = 0`

A data-layer-only fix would need to enforce `resp_len > 1` in every V1Dataset-producing path after tokenization/truncation, including the pretraining `data_io` pipeline. This runtime guard is defensive and keeps the normal FA3 hot path unchanged.

## Validation

- `python -m py_compile models/flash_attention_prefixlm_v2.py`
- `git diff --check origin/main..HEAD`
- local static guard check: normal causal backward uses `empty_like`, zero-causal branch uses `zeros_like`, and forward skips the zero-causal FA3 pass
- previous single-H100 zero-causal boundary repro: PASS
- previous 6 x 8 H100 training validation: reached `max_steps=2286`, crossing the previous failing step 2284
