### PR TITLE
Add optional sparse MoE FFN support with 64x8 validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,22 @@ Sizes live under [`config/arch/size`](config/arch/size):
 
 For HRM and RINS, `half_layers: true` splits the configured layer count evenly between the H and L modules.
 
+Optional sparse MoE size presets live in the same directory:
+
+| Config | Layers | Hidden | Heads | Experts | Active FFN width |
+| --- | ---: | ---: | ---: | --- | ---: |
+| `XL_moe64x8` | 32 | 1536 | 12 | 64 SwiGLU experts, top-k 8, expert width 512 | `8 * 512 = 4096` |
+
+The MoE preset keeps the per-token active FFN width aligned with dense `XL`
+while increasing total expert capacity. It uses fp32 router softmax, normalized
+top-k routing, and an auxiliary load-balancing loss. Launch it by overriding the
+size config:
+
+```bash
+torchrun --nproc_per_node=8 pretrain.py \
+  arch/size@arch=XL_moe64x8
+```
+
 ## Repository Layout
 
 ```text
@@ -262,7 +278,7 @@ HRM-Text/
 - [`dataset_new.py`](dataset_new.py) loads sampled `tokens.npy` and per-epoch index arrays, builds PrefixLM batches, masks instruction tokens by default, and emits FlashAttention sequence metadata.
 - [`multipack_sampler.py`](multipack_sampler.py) implements distributed multipack batching with LPT allocation to improve token-slot utilization and balance quadratic attention work.
 - [`models/flash_attention_prefixlm_v2.py`](models/flash_attention_prefixlm_v2.py) implements the two-pass PrefixLM attention path: one bidirectional pass over the prefix region and one causal pass over the response region.
-- [`models/layers.py`](models/layers.py) contains RoPE, gated multi-head attention, SwiGLU MLPs, static KV cache helpers, and initialization utilities.
+- [`models/layers.py`](models/layers.py) contains RoPE, gated multi-head attention, dense SwiGLU MLPs, optional sparse MoE SwiGLU MLPs, static KV cache helpers, and initialization utilities.
 - [`models/baselines/hrm_nocarry_bp_warmup.py`](models/baselines/hrm_nocarry_bp_warmup.py) contains the main HRM-Text architecture.
 - [`models/lm_head.py`](models/lm_head.py) attaches scaled embeddings, the output head, cross-entropy loss, token accuracy, and sequence exact accuracy.
 - [`pretrain.py`](pretrain.py) handles FSDP2 wrapping, optimizer creation, LR schedule, W&B logging, code/config snapshots, and distributed checkpointing.

--- a/config/arch/size/XL_moe64x8.yaml
+++ b/config/arch/size/XL_moe64x8.yaml
@@ -1,0 +1,25 @@
+# Backbone config
+n_layers: 32
+
+hidden_size: 1536
+num_heads: 12  # head size 128, min(2, hidden_size // 128)
+expansion: 4
+
+norm_type: pre  # TODO: Try different type of norms. Note that learning rate is dependent of norm type and init scale.
+norm_eps: 1e-6
+
+rope_theta: 10000.0
+pos_emb_type: rope
+
+# Simple Lecun Normal works better than Megatron init.
+# NOTE: Maybe larger init increases non-residual contribution, and layers are more effective?
+init_type: lecun_normal
+
+# Sparse MoE FFN. Each dense SwiGLU FFN has intermediate_size=4096 for XL; with
+# top_k=8 and moe_intermediate_size=512, the active expert FFN width matches the
+# dense FFN while total expert capacity increases.
+moe_num_experts: 64
+moe_top_k: 8
+moe_intermediate_size: 512
+moe_norm_topk_prob: true
+moe_router_aux_loss_coef: 0.001

--- a/models/layers.py
+++ b/models/layers.py
@@ -155,6 +155,16 @@ class Attention(nn.Module):
         return self.o_proj(attn_output)
 
 
+def load_balancing_loss_func(routing_probs: Tensor, selected_experts: Tensor, num_experts: int) -> Tensor:
+    """Qwen-style auxiliary load-balancing loss for top-k MoE routing."""
+    tokens_per_expert = torch.bincount(
+        selected_experts.reshape(-1),
+        minlength=num_experts,
+    ).to(torch.float32) / selected_experts.shape[0]
+    router_prob_per_expert = routing_probs.mean(dim=0)
+    return torch.sum(tokens_per_expert * router_prob_per_expert) * num_experts
+
+
 class SwiGLU(nn.Module):
     def __init__(self, hidden_size: int, intermediate_size: int, init_std_in=None, init_std_out=None, **kwargs):
         super().__init__()
@@ -163,6 +173,89 @@ class SwiGLU(nn.Module):
         self.down_proj    = LinearInit(intermediate_size, hidden_size,
                                        bias=False, init_std=init_std_out, **kwargs)
 
-    def forward(self, x):
+    def forward(self, x, **_seq_info):
         gate, up = self.gate_up_proj(x).chunk(2, dim=-1)
         return self.down_proj(F.silu(gate) * up)
+
+
+class SparseMoESwiGLU(nn.Module):
+    def __init__(self,
+                 hidden_size: int,
+                 intermediate_size: int,
+                 num_experts: int,
+                 top_k: int,
+                 norm_topk_prob: bool,
+                 init_std_in=None,
+                 init_std_out=None,
+                 **kwargs):
+        super().__init__()
+        if num_experts <= 0:
+            raise ValueError(f"num_experts must be positive, got {num_experts}")
+        if top_k <= 0 or top_k > num_experts:
+            raise ValueError(f"top_k must be in [1, num_experts], got top_k={top_k}, num_experts={num_experts}")
+        if init_std_in is None:
+            init_std_in = 1.0 / (hidden_size ** 0.5)
+        if init_std_out is None:
+            init_std_out = 1.0 / (intermediate_size ** 0.5)
+
+        self.hidden_size = hidden_size
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.norm_topk_prob = norm_topk_prob
+
+        self.gate = LinearInit(hidden_size, num_experts, bias=False, init_std=init_std_in, **kwargs)
+        self.gate_up_weight = nn.Parameter(
+            trunc_normal_init_(
+                torch.empty((num_experts, 2 * intermediate_size, hidden_size), **kwargs),
+                std=init_std_in
+            )
+        )
+        self.down_weight = nn.Parameter(
+            trunc_normal_init_(
+                torch.empty((num_experts, hidden_size, intermediate_size), **kwargs),
+                std=init_std_out
+            )
+        )
+
+    def forward(self,
+                x: Tensor,
+                moe_context: Optional[dict[str, Any]] = None,
+                total_seqlen: Optional[Tensor] = None,
+                **_seq_info) -> Tensor:
+        original_shape = x.shape
+        hidden_states = x.reshape(-1, self.hidden_size)
+
+        router_logits = self.gate(hidden_states)
+        routing_probs = F.softmax(router_logits, dim=-1, dtype=torch.float32)
+        routing_weights, selected_experts = torch.topk(routing_probs, self.top_k, dim=-1)
+        if self.norm_topk_prob:
+            routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        final_hidden_states = torch.zeros_like(hidden_states)
+        gate_up_weight = self.gate_up_weight.to(hidden_states.dtype)
+        down_weight = self.down_weight.to(hidden_states.dtype)
+        for expert_idx in range(self.num_experts):
+            token_idx, topk_idx = torch.where(selected_experts == expert_idx)
+            if token_idx.numel() == 0:
+                continue
+
+            expert_input = hidden_states[token_idx]
+            gate_up = F.linear(expert_input, gate_up_weight[expert_idx])
+            gate, up = gate_up.chunk(2, dim=-1)
+            expert_output = F.linear(F.silu(gate) * up, down_weight[expert_idx])
+            expert_output = expert_output * routing_weights[token_idx, topk_idx, None]
+            final_hidden_states.index_add_(0, token_idx, expert_output.to(hidden_states.dtype))
+
+        if moe_context is not None and torch.is_grad_enabled():
+            aux_routing_probs = routing_probs
+            aux_selected_experts = selected_experts
+            if total_seqlen is not None:
+                valid_tokens = int(unwrap_tensor(total_seqlen).item())
+                aux_routing_probs = aux_routing_probs[:valid_tokens]
+                aux_selected_experts = aux_selected_experts[:valid_tokens]
+
+            aux_loss = load_balancing_loss_func(aux_routing_probs, aux_selected_experts, self.num_experts)
+            moe_context.setdefault("aux_losses", []).append(aux_loss)
+
+        return final_hidden_states.reshape(original_shape)

--- a/models/lm_head.py
+++ b/models/lm_head.py
@@ -13,6 +13,8 @@ from models.common import IGNORE_LABEL_ID, packing_sequence_sum
 
 class LMHeadConfig(BaseModel):
     vocab_size: int
+    moe_num_experts: int = 0
+    moe_router_aux_loss_coef: float = 0.0
 
 
 class LMHead(nn.Module):
@@ -25,6 +27,8 @@ class LMHead(nn.Module):
         self.compute_train_extra_args = self.model.compute_train_extra_args
 
         config = LMHeadConfig(**config_dict)
+        self.moe_num_experts = config.moe_num_experts
+        self.moe_router_aux_loss_coef = config.moe_router_aux_loss_coef if self.moe_num_experts > 0 else 0.0
         head_hint: dict = self.model.head_hint  # pyright: ignore[reportAssignmentType]
 
         # LMHead input and output
@@ -36,9 +40,17 @@ class LMHead(nn.Module):
         input_embedding = self.embed_tokens(batch["inputs"])
 
         # Model forward
+        moe_context = None
+        if "labels" in batch and self.moe_num_experts > 0:
+            moe_context = {"aux_losses": []}
+
+        model_kwargs = {k: v for k, v in batch.items() if k not in ("inputs", "labels")}
+        if moe_context is not None:
+            model_kwargs["moe_context"] = moe_context
+
         new_carry, logits = self.model(carry,
                                        input_embedding,
-                                       **{k: v for k, v in batch.items() if k not in ("inputs", "labels")},
+                                       **model_kwargs,
                                        **kwargs)
         logits = self.lm_head(logits)
 
@@ -49,10 +61,18 @@ class LMHead(nn.Module):
             masks = labels != IGNORE_LABEL_ID
 
             # Loss (CE in F32)
-            loss = F.cross_entropy(logits.to(torch.float32), labels.to(torch.long), ignore_index=IGNORE_LABEL_ID, reduction="sum")
+            ce_loss = F.cross_entropy(logits.to(torch.float32), labels.to(torch.long), ignore_index=IGNORE_LABEL_ID, reduction="sum")
             # AllReduce loss divisor. Divide by mean of valid tokens across all processes, as gradient will be averaged.
             loss_divisor = masks.sum().to(torch.float32)
             dist.all_reduce(loss_divisor, op=dist.ReduceOp.AVG)
+            loss = ce_loss / loss_divisor
+
+            aux_loss = None
+            aux_loss_scaled = None
+            if moe_context is not None and moe_context["aux_losses"]:
+                aux_loss = torch.stack(moe_context["aux_losses"]).mean()
+                aux_loss_scaled = aux_loss * self.moe_router_aux_loss_coef
+                loss = loss + aux_loss_scaled
 
             # Accuracy
             with torch.no_grad():
@@ -64,11 +84,18 @@ class LMHead(nn.Module):
                 seq_is_valid = seq_num_valid_tokens > 0
                 # Metrics
                 metrics = {
-                    "loss": (loss.detach(), local_valid_counts),
+                    "loss": (ce_loss.detach(), local_valid_counts),
                     "accuracy": (is_correct.sum(), local_valid_counts),
                     "exact_accuracy": (((seq_num_tokens_correct == seq_num_valid_tokens) & seq_is_valid).sum(), seq_is_valid.sum()),
                 }
 
-            return new_carry, loss / loss_divisor, metrics
+                if moe_context is not None:
+                    one = torch.ones((), dtype=torch.float32, device=loss.device)
+                    zero = torch.zeros((), dtype=torch.float32, device=loss.device)
+                    metrics["moe_aux_loss"] = ((aux_loss.detach() if aux_loss is not None else zero), one)
+                    metrics["moe_aux_loss_scaled"] = ((aux_loss_scaled.detach() if aux_loss_scaled is not None else zero), one)
+                    metrics["moe_total_loss"] = (loss.detach(), one)
+
+            return new_carry, loss, metrics
 
         return new_carry, logits

--- a/models/transformer.py
+++ b/models/transformer.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 from pydantic import BaseModel
 
-from models.layers import SwiGLU, AttnType, Attention, Cache, RotaryEmbedding, find_multiple
+from models.layers import SwiGLU, SparseMoESwiGLU, AttnType, Attention, Cache, RotaryEmbedding, find_multiple
 
 
 class InitConfig(BaseModel):
@@ -26,6 +26,13 @@ class TransformerConfig(BaseModel):
     hidden_size: int
     num_heads: int
     expansion: float
+
+    # Qwen-style sparse MoE FFN. moe_num_experts=0 keeps the dense SwiGLU.
+    moe_num_experts: int = 0
+    moe_top_k: int = 1
+    moe_intermediate_size: Optional[int] = None
+    moe_norm_topk_prob: bool = True
+    moe_router_aux_loss_coef: float = 0.0
 
     attn_type: AttnType = "prefixlm"
 
@@ -75,25 +82,47 @@ class TransformerBlock(nn.Module):
             init_std_in=config.init_config.in_std,
             init_std_out=config.init_config.attn_out_std
         )
-        self.mlp = SwiGLU(
-            hidden_size=config.hidden_size,
-            intermediate_size=config.intermediate_size,
-            
-            init_std_in=config.init_config.in_std,
-            init_std_out=config.init_config.ff_out_std
-        )
+        if config.moe_num_experts > 0:
+            moe_intermediate_size = config.moe_intermediate_size
+            if moe_intermediate_size is None:
+                moe_intermediate_size = find_multiple(max(1, config.intermediate_size // config.moe_top_k), 256)
+
+            self.mlp = SparseMoESwiGLU(
+                hidden_size=config.hidden_size,
+                intermediate_size=moe_intermediate_size,
+                num_experts=config.moe_num_experts,
+                top_k=config.moe_top_k,
+                norm_topk_prob=config.moe_norm_topk_prob,
+
+                init_std_in=config.init_config.in_std,
+                init_std_out=config.init_config.ff_out_std
+            )
+        else:
+            self.mlp = SwiGLU(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+
+                init_std_in=config.init_config.in_std,
+                init_std_out=config.init_config.ff_out_std
+            )
         
         self.forward = getattr(self, f"_forward_{config.norm_type}")  # Avoid branching logic in "forward" for torch.compile compatibility
         self.norm = lambda x: F.rms_norm(x, (x.shape[-1], ), eps=config.norm_eps)
 
     # [Forward logic]
     def _forward_pre(self, x: Tensor, **seq_info) -> Tensor:  # Pre Norm
-        x = x + self.attn(self.norm(x), **seq_info)
-        return x + self.mlp(self.norm(x))
+        attn_seq_info = seq_info
+        if "moe_context" in seq_info:
+            attn_seq_info = {k: v for k, v in seq_info.items() if k != "moe_context"}
+        x = x + self.attn(self.norm(x), **attn_seq_info)
+        return x + self.mlp(self.norm(x), **seq_info)
     
     def _forward_post(self, x: Tensor, **seq_info) -> Tensor:  # Post Norm
-        x = self.norm(x + self.attn(x, **seq_info))
-        return self.norm(x + self.mlp(x))
+        attn_seq_info = seq_info
+        if "moe_context" in seq_info:
+            attn_seq_info = {k: v for k, v in seq_info.items() if k != "moe_context"}
+        x = self.norm(x + self.attn(x, **attn_seq_info))
+        return self.norm(x + self.mlp(x, **seq_info))
 
 
 class Transformer(nn.Module):


### PR DESCRIPTION
## Summary

  This PR adds optional sparse MoE FFN support to HRM-Text while keeping the default dense configuration unchanged.

  The new XL_moe64x8 preset replaces each dense SwiGLU FFN with a routed sparse MoE FFN:

  - 64 SwiGLU experts
  - top-k = 8 active experts per token
  - expert intermediate size = 512
  - active FFN width = 8 * 512 = 4096, matching dense XL
  - auxiliary router load-balancing loss

  This is intended as an optional model-quality/configuration path, not a default replacement for dense HRM-Text.

  ## What changed

  - Adds SparseMoESwiGLU as an optional FFN layer.
  - Extends TransformerConfig with MoE fields, defaulting to dense behavior with moe_num_experts=0.
  - Adds MoE auxiliary loss handling in LMHead.
  - Adds config/arch/size/XL_moe64x8.yaml.
  - Documents the optional MoE preset in the README.

  ## Reference checkpoint and scale validation

  We trained and exported a 64x8 HRM-MoE checkpoint here:

  https://huggingface.co/Xiaoye08/HRM-MoE

  The checkpoint demonstrates the intended sparse-activation setup: total parameters increase to ~5.41B, while active
  parameters per token remain close to dense HRM-Text XL (~1.18B active/token). This gives a larger expert parameter pool
  without substantially increasing per-token activated model size.

  Selected 32-GPU HRM-MoE results versus our dense HRM-Text XL baseline (Our Implementation on 32-GPU):

  - GSM8k acc: 83.93 -> 84.99
  - MATH acc: 54.96 -> 60.08
  - DROP F1: 83.06 -> 84.53
  - ARC acc: 83.02 -> 87.80
  - HellaSwag acc: 61.96 -> 73.89
  - BoolQ acc: 87.25 -> 88.75
  - MMLU-Pro acc: 32.72 -> 37.57

  ## Validation

  Local validation run for this PR:

  - python -m py_compile models/layers.py models/transformer.py models/lm_head.py
  - Sparse MoE layer forward/backward smoke test with finite gradients for input, router, and expert weights